### PR TITLE
Return the correct Variant ID in case the Chain ID is not in the Chai…

### DIFF
--- a/SigningRequestConstants.cs
+++ b/SigningRequestConstants.cs
@@ -80,7 +80,7 @@ namespace EosioSigningRequest
                     return new KeyValuePair<string, object>("chain_alias", (byte) chainIdEnum);
                 return new KeyValuePair<string, object>("chain_id", ChainIdLookup[(ChainName)chainIdEnum]);
             }
-            return new KeyValuePair<string, object>("chain_alias", chainId);
+            return new KeyValuePair<string, object>("chain_id", chainId);
         }
     }
 }


### PR DESCRIPTION
**Title:**
Replace `chain_alias` with `chain_id` to Fix ChainId parsing Issue

**Description:**
While using this library with the WAX testnet, an issue was observed where the function VariantId couldn't locate the chain id on the ChainIdLookup dictionary to subsequently misinterpret the `chain_alias`, causing a parsing error.

Changes:

Changed the return value from:
`return new KeyValuePair<string, object>("chain_alias", chainId);
`to:
`return new KeyValuePair<string, object>("chain_id", chainId);
`
**Motivation & Context:**
Upon consulting the Greymass documentation, we identified that in cases where a `chain_alias` is not found, returning the `chain_id` is the recommended approach. This PR aligns the code with this documentation to resolve the observed issue.

How Has This Been Tested?
I have done extensive local test only using the WAX MainNet and TestNet
The library was used on the WAX testnet, and the issue is no longer observed.

Documentation & References:

Greymass eosio-signing-request protocol specification: [Link](https://github.com/greymass/eosio-signing-request/blob/master/protocol-specification.md)